### PR TITLE
Check readiness only after block

### DIFF
--- a/src/eventfd.rs
+++ b/src/eventfd.rs
@@ -90,6 +90,13 @@ impl AsyncEventFd {
     }
 
     pub async fn write(&self, val: u64) -> io::Result<()> {
+        match self.0.get_ref().write(val) {
+            Ok(()) => return Ok(()),
+            Err(err) => if err.kind() != io::ErrorKind::WouldBlock {
+                return Err(err)
+            },
+        }
+
         loop {
             let mut guard = self.0.writable().await?;
 

--- a/src/eventfd.rs
+++ b/src/eventfd.rs
@@ -31,7 +31,7 @@ impl EventFd {
         Ok(Self(rv))
     }
 
-    pub fn read(&self) -> std::io::Result<u64> {
+    pub fn read(&self) -> io::Result<u64> {
         let mut val: u64 = 0;
         let val_ptr: *mut u64 = &mut val;
 
@@ -107,7 +107,14 @@ impl AsyncEventFd {
         }
     }
 
-    pub async fn read(&self) -> std::io::Result<u64> {
+    pub async fn read(&self) -> io::Result<u64> {
+        match self.0.get_ref().read() {
+            Ok(result) => return Ok(result),
+            Err(err) => if err.kind() != io::ErrorKind::WouldBlock {
+                return Err(err)
+            },
+        }
+
         loop {
             let mut guard = self.0.readable().await?;
 


### PR DESCRIPTION
In `tokio::io::unix::AsyncFd` documentation [stated](https://docs.rs/tokio/1.13.0/tokio/io/unix/struct.AsyncFd.html):
> On some platforms, the readiness detecting mechanism relies on edge-triggered notifications. This means that the OS will only notify Tokio when the file descriptor transitions from not-ready to ready. For this to work you should first try to read or write and only poll for readiness if that fails with an error of std::io::ErrorKind::WouldBlock.
